### PR TITLE
chore: remove wdm gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,9 +29,6 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
   gem "tzinfo-data"
 end
 
-# Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.2.0" if Gem.win_platform?
-
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,6 @@ GEM
     unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
     uri (1.1.1)
-    wdm (0.2.0)
     webrick (1.9.2)
 
 PLATFORMS
@@ -302,7 +301,6 @@ DEPENDENCIES
   minima (~> 2.5)
   tzinfo (>= 1, < 3)
   tzinfo-data
-  wdm (~> 0.2.0)
   webrick
 
 BUNDLED WITH


### PR DESCRIPTION
The wdm gem was used for performance-boosting directory watching on Windows, but it is no longer needed.