### PR TITLE
fix: replace placeholder HPGE answers with May 2019 key

### DIFF
--- a/_data/keys_HPGE-01.yaml
+++ b/_data/keys_HPGE-01.yaml
@@ -1,11 +1,49 @@
-title: "HPGE Answer Sheet"
+title: "Answer Sheets for GERTC HGE (May 2019)"
 answers:
+  - D
+  - B
+  - D
+  - B
+  - B
   - A
+  - C
+  - C
   - A
-  - A
-  - A
-  - A
-  - A
-  - A
+  - C
+  - B
+  - C
+  - B
+  - C
+  - B
+  - D
+  - C
+  - D
   - A
   - B
+  - A
+  - D
+  - C
+  - B
+  - C
+  - B
+  - B
+  - B
+  - D
+  - C
+  - A
+  - A
+  - D
+  - D
+  - A
+  - C
+  - A
+  - B
+  - D
+  - B
+  - D
+  - C
+  - C
+  - A
+  - D
+  - A
+  - C

--- a/_posts/2026-08-09-HPGE.markdown
+++ b/_posts/2026-08-09-HPGE.markdown
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "[TEST] HPGE Answer Sheet"
+title: "GILLESANIA CE REF Vol 5 HGE (May 2019) Answer Sheet"
 date: 2026-08-09 00:00:00 +0800
 answer_key_file: keys_HPGE-01
 sheet_title: HPGE Answer Sheet


### PR DESCRIPTION
Update the answer key YAML with the correct answers for the GERTC HGE (May 2019) exam, and adjust the post title to reference the GILLESANIA CE REF Vol 5 source.